### PR TITLE
automatically include 'dependency' as -autocp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir dependency
 
 # Creating executable
 RUN /bin/sh -c "echo \"#!/bin/sh\" > /verveinej-docker.sh"
-RUN /bin/sh -c "echo \"/VerveineJ-3.0.7/verveinej.sh -autocp /dependency $* .\" >> /verveinej-docker.sh"
+RUN /bin/sh -c "echo \"/VerveineJ-3.0.7/verveinej.sh $* -autocp /dependency .\" >> /verveinej-docker.sh"
 RUN chmod +x /verveinej-docker.sh
 
 # Download VerveineJ

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,21 @@ FROM eclipse-temurin:17
 
 
 # Update
-RUN apt-get update
 RUN apt-get install -y wget
 
 # Set up file system
-
 RUN mkdir src
 RUN mkdir dependency
 
-# Download VerveineJ
+# Creating executable
+RUN /bin/sh -c "echo \"#!/bin/sh\" > /verveinej-docker.sh"
+RUN /bin/sh -c "echo \"/VerveineJ-3.0.7/verveinej.sh -autocp /dependency $* .\" >> /verveinej-docker.sh"
+RUN chmod +x /verveinej-docker.sh
 
+# Download VerveineJ
 RUN wget -r https://github.com/moosetechnology/VerveineJ/archive/refs/tags/v3.0.7.tar.gz -O verveine.tar.gz 
 RUN tar -xvf verveine.tar.gz
 
 WORKDIR /src
 
-ENTRYPOINT [ "/VerveineJ-3.0.7/verveinej.sh" ]
+ENTRYPOINT [ "/verveinej-docker.sh" ]


### PR DESCRIPTION
fix #2

Creates a shell scripts that invokes verveinej with some default arguments
- default  '-autocp dependency' argument
- default '.' argument at the end of command line 
- other arguments are inserted in between these 2