### PR TITLE
release v3.2.2 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ COPY verveinej-docker.sh /verveinej-docker.sh
 RUN chmod +x /verveinej-docker.sh
 
 # Download VerveineJ
-RUN wget -r https://github.com/moosetechnology/VerveineJ/archive/refs/tags/v3.2.1.tar.gz -O verveine.tar.gz 
+RUN wget -r https://github.com/moosetechnology/VerveineJ/archive/refs/tags/v3.2.2.tar.gz -O verveine.tar.gz 
 RUN tar -xvf verveine.tar.gz
+RUN mv VerveineJ-3.2.2 VerveineJ-latest
 
 WORKDIR /src
 

--- a/verveinej-docker.sh
+++ b/verveinej-docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/VerveineJ-3.2.1/verveinej.sh $@ -autocp /dependency .
+/VerveineJ-latest/verveinej.sh $@ -autocp /dependency .


### PR DESCRIPTION
Updated Dockerfile to use release v3.2.2
changed the script so that we will not need to also update 'verveinej-docker.sh' in the future