### PR TITLE
Nicolas anquetil cannot find verveinej jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY verveinej-docker.sh /verveinej-docker.sh
 RUN chmod +x /verveinej-docker.sh
 
 # Download VerveineJ
-RUN wget https://github.com/moosetechnology/VerveineJ/releases/download/v3.2.4/VerveineJ-v3.2.4.jar -O VerveineJ.jar
+RUN wget https://github.com/moosetechnology/VerveineJ/releases/download/v3.2.4/VerveineJ-v3.2.4.jar -O /VerveineJ.jar
 
 WORKDIR /src
 

--- a/verveinej-docker.sh
+++ b/verveinej-docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar VerveineJ.jar $@ -autocp /dependency .
+java -jar /VerveineJ.jar $@ -autocp /dependency .


### PR DESCRIPTION
forced copy of VerveineJ.jar in root directory (Dockerfile) and using it there (verveinej-docker.sh)